### PR TITLE
Change to SPDX License Identifier (MIT) for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Access HPCloud and OpenStack services in PHP.",
   "type": "library",
   "keywords": ["openstack","hpcloud","cloud","swift","nova"],
-  "license": "MIT-like",
+  "license": "MIT",
   "homepage": "http://hpcloud.com",
   "authors": [
     {


### PR DESCRIPTION
The `composer validate` command is now supporting [SPDX license identifers](http://spdx.org/licenses/).

As your package is used within other codebases (and has a composer.json file) I kindly ask you to change the license identifier in [`composer.json`](https://github.com/hpcloud/HPCloud-PHP/blob/5d84d79dd1a46d31bd68ce89694e2d674046bccf/composer.json) from `MIT-like` to `MIT` ([_MIT License_](http://spdx.org/licenses/MIT)).

This suggestion has been done in good faith and is not a change of the license, just the way how it is identified. See as well [composer.json license property](http://getcomposer.org/doc/04-schema.md#license).

---

License text: [`LICENSE.txt` file](https://github.com/hpcloud/HPCloud-PHP/blob/8c3006df3a70ed77e78adca3a774434d5cf516db/LICENSE.txt) 8c3006df3a70ed77e78adca3a774434d5cf516db
Text Reviewed against: http://spdx.org/licenses/MIT ([git vcs](http://git.spdx.org/?p=spdx-tools.git;a=blob;f=resources/stdlicenses/MIT;h=fc96b3e47659627bba946175ccac3bfe658c707a;hb=89de0378951b1109682fefa056cfa1c53ea7d147))
Review: Placeholders are filled in, Header "MIT License" not given, "(c) Copyright" as "Copyright (c)" and no other differences than whitespace.
Review result: Match
Review result license identifier: `MIT`
