### PR TITLE
Disable HTTP 1.1 connection keep-alive

### DIFF
--- a/src/HPCloud/Transport/PHPStreamTransport.php
+++ b/src/HPCloud/Transport/PHPStreamTransport.php
@@ -234,6 +234,7 @@ class PHPStreamTransport implements Transporter {
    */
   protected function buildStreamContext($method, $headers, $body) {
     // Construct the stream options.
+    $headers['Connection'] = 'close';
     $config = array(
       'http' => array(
         'protocol_version' => $this->httpVersion,


### PR DESCRIPTION
As [1] states:
If this value is set to 1.1 it is your responsibility to be 1.1
compliant.

PHP doesn't support Connection: keep-alive and feof will wait until the
timeout of the webserver it reached (5 seconds for Apache).

This patch adds Connection: close to the headers of PHPStreamTransport
to prevent keep-alive for HTTP 1.1 requests.
1. http://www.php.net/manual/en/context.http.php#context.http.protocol-version
