### PR TITLE
Changed newFromServiceCatalog to return the first endpoint if the DEFAULT is not found

### DIFF
--- a/src/HPCloud/Storage/ObjectStorage.php
+++ b/src/HPCloud/Storage/ObjectStorage.php
@@ -190,8 +190,10 @@ class ObjectStorage {
    * The IdentityServices object contains a service catalog listing all of the
    * services to which the present account has access.
    *
-   * This builder can scan the catalog and generate a new ObjectStorage
-   * instance pointed to the first object storage endpoint in the catalog.
+   * This builder scans the catalog and generate a new ObjectStorage
+   * instance pointed to the object storage endpoing matching the region
+   * specied. If no region is specified, the first  object storage endpoint in
+   * the catalog is used.
    *
    * @param array $catalog
    *   The serice catalog from IdentityServices::serviceCatalog(). This
@@ -213,6 +215,24 @@ class ObjectStorage {
             //$cdn->url = $endpoint['publicURL'];
 
             return $os;
+          }
+        }
+      }
+    }
+
+// If no specific region was specified, we return the first endpoint of the
+// correct type as we did not match on a given region in the previous for loop.
+
+    if ($region == ObjectStorage::DEFAULT_REGION) {
+      for ($i = 0; $i < $c; ++$i) {
+        if ($catalog[$i]['type'] == self::SERVICE_TYPE) {
+          foreach ($catalog[$i]['endpoints'] as $endpoint) {
+            if (isset($endpoint['publicURL'])) {
+              $os= new ObjectStorage($authToken, $endpoint['publicURL']);
+              //$cdn->url = $endpoint['publicURL'];
+  
+              return $os;
+            }
           }
         }
       }


### PR DESCRIPTION
If the default region is not found and a user has not explicitly specified a region, return the first usable endpoint. This change allows the library to be used on private and other public clouds without specifying the region. Third party application support for specifying a region is a bit hit and miss, and often times a service catalog only has a single region in which case explicitly specifying a region is not always remembered.
